### PR TITLE
Fix check ami when file is empty

### DIFF
--- a/check-deprecated-ami/ami-check.sh
+++ b/check-deprecated-ami/ami-check.sh
@@ -15,7 +15,7 @@ aws ec2 describe-instances --query 'Reservations[*].Instances[*].{Project:Tags[?
 
 echo finding deprecated images...
 grep -v -f all.txt inuse.txt > deprecated.txt
-if grep ami  deprecated.txt ; then
+if grep ami-  deprecated.txt ; then
 	echo DEPRECATED AMIS FOUND
 	exit 1
 fi

--- a/check-deprecated-ami/ami-check.sh
+++ b/check-deprecated-ami/ami-check.sh
@@ -15,7 +15,7 @@ aws ec2 describe-instances --query 'Reservations[*].Instances[*].{Project:Tags[?
 
 echo finding deprecated images...
 grep -v -f all.txt inuse.txt > deprecated.txt
-if [ $? -ne 0 ]; then
+if grep ami  deprecated.txt ; then
 	echo DEPRECATED AMIS FOUND
 	exit 1
 fi

--- a/check-deprecated-ami/ami-check.sh
+++ b/check-deprecated-ami/ami-check.sh
@@ -15,8 +15,7 @@ aws ec2 describe-instances --query 'Reservations[*].Instances[*].{Project:Tags[?
 
 echo finding deprecated images...
 grep -v -f all.txt inuse.txt > deprecated.txt
-
-if [ -s deprecated.txt ]; then
+if [ $? -ne 0 ]; then
 	echo DEPRECATED AMIS FOUND
 	exit 1
 fi


### PR DESCRIPTION
It seems that `if [ -s deprecated.txt ]; then` doesn't work because our 'empty' file looks like this

```
---------------------------------------------------------------------------------------------------------------
|                                              DescribeInstances                                              |
+-----------------------+----------------------+------------------------------------------+-------------------+
|          AMI          |      Instance        |                  Name                    |      Project      |
+-----------------------+----------------------+------------------------------------------+-------------------+
+-----------------------+----------------------+------------------------------------------+-------------------+
```
so, let's check for ami-
